### PR TITLE
CRUD Options + routes Options

### DIFF
--- a/api/controllers/optionController.js
+++ b/api/controllers/optionController.js
@@ -1,0 +1,254 @@
+/**
+ * @fileoverview Contrôleur des options
+ * @module controllers/optionController
+ */
+
+const { Option, Eleve } = require('../models');
+
+/**
+ * retourne toutes les options disponibles
+ *
+ * @async
+ * @function getAll
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // GET /options
+ * // Réponse 200 : [{ id: 1, nom: "Espagnol", type: "langue" }, ...]
+ */
+
+const getAll = async (req, res) => {
+    try {
+        const options = await Option.findAll();
+        res.status(200).json(options);
+    } catch (error) {
+        console.error('Erreur getAll options:', error);
+        res.status(500).json({ message: 'Erreur serveur' });
+    }
+};
+
+/**
+ * retourne les options d'un élève
+ *
+ * @async
+ * @function getByEleve
+ * @param {import('express').Request} req
+ * @param {string} req.params.id - Id de l'élève
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // GET /eleves/1/options
+ * // Réponse 200 : [{ id: 1, nom: "Espagnol", type: "langue" }]
+ * // Réponse 404 : { message: "Élève introuvable" }
+ */
+
+const getByEleve = async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        const eleve = await Eleve.findByPk(id, {
+            include: [{ model: Option }]
+        });
+        if (!eleve) {
+            return res.status(404).json({ message: 'Élève introuvable' });
+        }
+
+        const options = await eleve.getOptions();
+        res.status(200).json(options);
+
+    } catch (error) {
+        console.error('Erreur getByEleve options:', error);
+        res.status(500).json({ message: 'Erreur serveur' });
+    }
+};
+
+/**
+ * crée une nouvelle option dans le catalogue.
+ *
+ * @async
+ * @function create
+ * @param {import('express').Request} req 
+ * @param {Object} req.body 
+ * @param {string} req.body.nom - Nom de l'option (ex: "Espagnol")
+ * @param {string} req.body.type - Type de l'option ("langue" ou "technique")
+ * @param {import('express').Response} res 
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // POST /options
+ * // Body : { "nom": "Espagnol", "type": "langue" }
+ * // Réponse 201 : { id: 1, nom: "Espagnol", type: "langue" }
+ * // Réponse 400 : { message: "Type invalide" }
+ */
+
+const create = async (req, res) => {
+    try {
+        const { nom, type } = req.body;
+
+        if (!nom || !type) {
+            return res.status(400).json({ message: 'Champs manquants' });
+        }
+
+        if (type !== 'langue' && type !== 'technique') {
+            return res.status(400).json({ message: 'Type invalide' });
+        }
+
+        const option = await Option.create({ nom, type });
+        res.status(201).json(option);
+
+    } catch (error) {
+        console.error('Erreur create option:', error);
+        res.status(500).json({ message: 'Erreur serveur' });
+    }
+};
+
+/**
+ * affecte une option à un élève.
+ * un élève ne peut pas avoir plus de 2 options.
+ *
+ * @async
+ * @function affecter
+ * @param {import('express').Request} req 
+ * @param {Object} req.body 
+ * @param {number} req.body.eleve_id - Id de l'élève
+ * @param {number} req.body.option_id - Id de l'option
+ * @param {import('express').Response} res 
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // POST /options/affecter
+ * // Body : { "eleve_id": 1, "option_id": 1 }
+ * // Réponse 201 : { message: "Option affectée avec succès" }
+ * // Réponse 400 : { message: "Maximum 2 options atteint" }
+ * // Réponse 409 : { message: "Élève déjà inscrit à cette option" }
+ */
+
+const affecter = async (req, res) => {
+    try {
+        const { eleve_id, option_id } = req.body;
+
+        if (!eleve_id || !option_id) {
+            return res.status(400).json({ message: 'Champs manquants' });
+        }
+
+        const eleve = await Eleve.findByPk(eleve_id);
+        if (!eleve) {
+            return res.status(404).json({ message: 'Élève introuvable' });
+        }
+
+        const option = await Option.findByPk(option_id);
+        if (!option) {
+            return res.status(404).json({ message: 'Option introuvable' });
+        }
+
+        const nbOptions = await eleve.countOptions();
+        if (nbOptions >= 2) {
+            return res.status(400).json({ message: 'Maximum 2 options atteint' });
+        }
+
+        // Vérifier doublon
+        const options = await eleve.getOptions({ where: { id: option_id } });
+        if (options.length > 0) {
+            return res.status(409).json({ message: 'Élève déjà inscrit à cette option' });
+        }
+
+        await eleve.addOption(option); //addOption car relation Many-to-Many, avec create il ne sait pas que c'est une table d'association
+        res.status(201).json({ message: 'Option affectée avec succès' });
+
+    } catch (error) {
+        console.error('Erreur affecter option:', error);
+        res.status(500).json({ message: 'Erreur serveur' });
+    }
+};
+
+/**
+ * retire une option d'un élève
+ *
+ * @async
+ * @function retirer
+ * @param {import('express').Request} req 
+ * @param {Object} req.body 
+ * @param {number} req.body.eleve_id - Id de l'élève
+ * @param {number} req.body.option_id - Id de l'option
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // DELETE /options/retirer
+ * // Body : { "eleve_id": 1, "option_id": 1 }
+ * // Réponse 200 : { message: "Option retirée avec succès" }
+ * // Réponse 404 : { message: "Élève non inscrit à cette option" }
+ */
+
+const retirer = async (req, res) => {
+    try {
+        const { eleve_id, option_id } = req.body;
+
+        if (!eleve_id || !option_id) {
+            return res.status(400).json({ message: 'Champs manquants' });
+        }
+
+        const eleve = await Eleve.findByPk(eleve_id);
+        if (!eleve) {
+            return res.status(404).json({ message: 'Élève introuvable' });
+        }
+
+        const option = await Option.findByPk(option_id);
+        if (!option) {
+            return res.status(404).json({ message: 'Option introuvable' });
+        }
+
+        const hasOption = await eleve.hasOption(option);
+        if (!hasOption) {
+            return res.status(404).json({ message: 'Élève non inscrit à cette option' });
+        }
+
+        await eleve.removeOption(option);
+        res.status(200).json({ message: 'Option retirée avec succès' });
+
+    } catch (error) {
+        console.error('Erreur retirer option:', error);
+        res.status(500).json({ message: 'Erreur serveur' });
+    }
+};
+
+/**
+ * supprime une option du catalogue
+ * supprime automatiquement toutes les liaisons élève-option associées (CASCADE)
+ *
+ * @async
+ * @function remove
+ * @param {import('express').Request} req 
+ * @param {string} req.params.id - Id de l'option à supprimer
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // DELETE /options/1
+ * // Réponse 200 : { message: "Option supprimée" }
+ * // Réponse 404 : { message: "Option introuvable" }
+ */
+
+const remove = async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        const option = await Option.findByPk(id);
+        if (!option) {
+            return res.status(404).json({ message: 'Option introuvable' });
+        }
+
+        await option.destroy();
+        res.status(200).json({ message: 'Option supprimée' });
+
+    } catch (error) {
+        console.error('Erreur remove option:', error);
+        res.status(500).json({ message: 'Erreur serveur' });
+    }
+}
+
+
+module.exports = { getAll, getByEleve, create, affecter, retirer, remove };

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -78,8 +78,8 @@ Participation.belongsTo(Projet,  { foreignKey: 'projet_id' })
 
 // ── Options ───────────────────────────────────────────────────
 // Many-to-many : un élève a plusieurs options, une option a plusieurs élèves
-Eleve.belongsToMany(Option,      { through: 'eleve_option', foreignKey: 'eleve_id' })
-Option.belongsToMany(Eleve,      { through: 'eleve_option', foreignKey: 'option_id' })
+Eleve.belongsToMany(Option,      { through: 'eleve_option', foreignKey: 'eleve_id', timestamps: false })
+Option.belongsToMany(Eleve,      { through: 'eleve_option', foreignKey: 'option_id', timestamps: false })
 
 // ── Export de tous les modèles ────────────────────────────────
 module.exports = {

--- a/api/routes/eleves.js
+++ b/api/routes/eleves.js
@@ -7,14 +7,16 @@ const express = require('express');
 const router = express.Router();
 const eleveController = require('../controllers/eleveController');
 const moyenneController = require('../controllers/moyenneController');
+const optionController = require('../controllers/optionController');
 const verifyToken = require('../middlewares/verifyToken');
 const checkRole = require('../middlewares/checkRole');
 const upload = require('../middlewares/upload');
 
+router.get('/:id/options',  verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), optionController.getByEleve);
+router.get('/:id/moyennes', verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), moyenneController.getByEleve);
 router.post('/import',      verifyToken, checkRole('secretariat'), upload.single('fichier'), eleveController.importCSV);
 router.get('/',             verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), eleveController.getAll);
 router.get('/:id',          verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), eleveController.getById);
-router.get('/:id/moyennes', verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), moyenneController.getByEleve);
 router.post('/',            verifyToken, checkRole('secretariat'),                            eleveController.create);
 router.put('/:id',          verifyToken, checkRole('secretariat'),                            eleveController.update);
 router.delete('/:id',       verifyToken, checkRole('secretariat'),                            eleveController.remove);

--- a/api/routes/options.js
+++ b/api/routes/options.js
@@ -1,0 +1,18 @@
+/**
+ * @fileoverview Routes des options
+ * @module routes/options
+ */
+
+const express = require('express');
+const router = express.Router();
+const optionController = require('../controllers/optionController');
+const verifyToken = require('../middlewares/verifyToken');
+const checkRole = require('../middlewares/checkRole');
+
+router.get('/',           verifyToken, checkRole('secretariat', 'proviseur', 'professeur', 'eleve'), optionController.getAll);
+router.post('/',          verifyToken, checkRole('secretariat'),                                     optionController.create);
+router.post('/affecter',  verifyToken, checkRole('secretariat'),                                     optionController.affecter);
+router.delete('/retirer', verifyToken, checkRole('secretariat'),                                     optionController.retirer);
+router.delete('/:id',     verifyToken, checkRole('secretariat'),                                     optionController.remove);
+
+module.exports = router;

--- a/api/server.js
+++ b/api/server.js
@@ -3,11 +3,13 @@ dotenv.config()
 
 const express  = require('express')
 const { connectDB } = require('./config/database')
+
 const auth     = require('./routes/auth')
 const eleves = require('./routes/eleves')
 const moyenne = require('./routes/moyenne')
 const stages = require('./routes/stages')
 const projets = require('./routes/projets')
+const options = require('./routes/options')
 
 const app  = express()
 const PORT = process.env.PORT || 3000
@@ -18,6 +20,7 @@ app.use('/eleves', eleves)
 app.use('/moyennes', moyenne)
 app.use('/stages', stages)
 app.use('/projets', projets)
+app.use('/options', options)
 
 connectDB()
 require('./models')


### PR DESCRIPTION
## Description
Implémentation du CRUD des options avec gestion des affectations élèves, routes et tests flashposts

## Changements
- Ajout de `controllers/optionController.js` - getAll, getByEleve, create, affecter, retirer, remove
- Ajout de `routes/options.js` - routes sécurisées par rôle
- Mise à jour de `routes/eleves.js` - ajout GET /:id/options
- Mise à jour de `server.js` - branchement /options
- Fix `models/index.js` - ajout timestamps: false sur belongsToMany eleve_option car sequelize cherchait updated_at -> erreur

## Tests
- GET /options → liste toutes les options ✅
- POST /options → création avec validation du type ✅
- POST /options/affecter → affectation avec max 2 options ✅
- DELETE /options/retirer → retrait option élève ✅
- DELETE /options/:id → suppression catalogue ✅
- GET /eleves/:id/options → options d'un élève ✅

## Closes
Closes #32 