### PR TITLE
prof referent, affectation auto et manuelle + routes

### DIFF
--- a/api/controllers/professeurController.js
+++ b/api/controllers/professeurController.js
@@ -1,0 +1,210 @@
+/**
+ * @fileoverview Contrôleur des professeurs référents
+ * @module controllers/professeurController
+ */
+
+const { Professeur, Eleve, Classe, Niveau } = require('../models');
+const { fn, col } = require('sequelize');
+
+/**
+ * retourne la liste des élèves dont ce professeur est référent.
+ *
+ * @async
+ * @function getEleves
+ * @param {import('express').Request} req
+ * @param {string} req.params.id - Id du professeur
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // GET /professeurs/1/eleves
+ * // Réponse 200 : [{ id: 1, nom: "Isik", prenom: "Imran", classe: { ... } }]
+ * // Réponse 404 : { message: "Professeur introuvable" }
+ */
+
+const getEleves = async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        const professeur = await Professeur.findByPk(id);
+        if (!professeur) {
+            return res.status(404).json({ message: 'Professeur introuvable' });
+        }
+
+        const eleves = await professeur.getEleves_referents({ //select * from eleves where professeur_id = id en sequelize
+            include: [ //pour avoir les infos de la classe et du niveau
+                {
+                    model: Classe,
+                    include: [{ model: Niveau }]
+                }
+            ]
+        });
+        res.status(200).json(eleves);
+
+    } catch (error) {
+        console.error('Erreur getEleves:', error);
+        res.status(500).json({ message: 'Erreur serveur' });
+    }
+};
+
+/**
+ * retourne la liste de tous les professeurs avec leur nombre d'élèves référents.
+ *
+ * @async
+ * @function getAll
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // GET /professeurs
+ * // Réponse 200 : [{ id: 1, nom: "Dupont", prenom: "Jean", nb_eleves: 5 }]
+ */
+
+const getAll = async (req, res) => {
+    try {
+        // fn('COUNT') et col() sont des helpers Sequelize pour écrire du SQL
+        // équivalent de SELECT COUNT (eleves.id) AS nb_eleves FROM professeurs
+
+        const professeurs = await Professeur.findAll({
+            subQuery: false,
+            include: [{
+                model: Eleve,
+                as: 'eleves_referents',
+                attributes: [] // pas besoin des données des élèves, juste le compte
+            }],
+            attributes: [
+                'id',
+                'nom',
+                'prenom',
+                [fn('COUNT', col('eleves_referents.id')), 'nb_eleves'] // compte le nombre d'eleves pour chaque prof
+            ],
+            group: ['professeur.id'], // resultats par prof , (GROUP BY)
+            order: [['nom', 'ASC']] // ordre croissant (ORDER BY), le moins chargé en premier
+        });
+        res.status(200).json(professeurs);
+    } catch (error) {
+        console.error('Erreur getAll:', error);
+        res.status(500).json({ message: 'Erreur serveur' });
+    }
+};
+
+/**
+ * affecte manuellement un professeur référent à un élève.
+ *
+ * @async
+ * @function affecter
+ * @param {import('express').Request} req
+ * @param {string} req.params.id - Id de l'élève
+ * @param {Object} req.body
+ * @param {number} req.body.professeur_id - Id du professeur à affecter
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // POST /eleves/1/referent
+ * // Body : { "professeur_id": 2 }
+ * // Réponse 200 : { message: "Référent affecté avec succès", eleve: { ... } }
+ * // Réponse 404 : { message: "Élève introuvable" }
+ */
+
+const affecter = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const { professeur_id } = req.body;
+
+        if (!professeur_id) {
+            return res.status(400).json({ message: 'professeur_id manquant' });
+        }
+
+        const eleve = await Eleve.findByPk(id);
+        if (!eleve) {
+            return res.status(404).json({ message: 'Élève introuvable' });
+        }
+
+        const professeur = await Professeur.findByPk(professeur_id);
+        if (!professeur) {
+            return res.status(404).json({ message: 'Professeur introuvable' });
+        }
+
+        eleve.professeur_id = professeur_id;
+        await eleve.save(); //envoie le UPDATE en BDD
+
+        res.status(200).json({ message: 'Référent affecté avec succès', eleve });
+
+    } catch (error) {
+        console.error('Erreur affecter:', error);
+        res.status(500).json({ message: 'Erreur serveur' });
+    }
+};
+
+
+/**
+ * affecte automatiquement le professeur référent avec le moins d'élèves (round-robin).
+ *
+ * @async
+ * @function affecterAuto
+ * @param {import('express').Request} req 
+ * @param {string} req.params.id - Id de l'élève
+ * @param {import('express').Response} res 
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // POST /eleves/1/referent/auto
+ * // Réponse 200 : { message: "Référent affecté automatiquement", eleve: { ... }, professeur: { ... } }
+ * // Réponse 404 : { message: "Aucun professeur disponible" }
+ */
+
+const affecterAuto = async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        const eleve = await Eleve.findByPk(id);
+        if (!eleve) {
+            return res.status(404).json({ message: 'Élève introuvable' });
+        }
+
+        // limit 1 : on prend uniquement le premier
+        const professeurs = await Professeur.findAll({
+            subQuery: false, 
+            include: [{
+                model: Eleve,
+                as: 'eleves_referents',
+                attributes: [] 
+            }],
+            attributes: [
+                'id',
+                'nom',
+                'prenom',
+                [fn('COUNT', col('eleves_referents.id')), 'nb_eleves']
+            ],
+            group: ['professeur.id'],
+            order: [[fn('COUNT', col('eleves_referents.id')), 'ASC']],
+            limit: 1
+        });
+
+        if (!professeurs.length) {
+            return res.status(404).json({ message: 'Aucun professeur disponible' });
+        }
+
+        const professeurLeMoinsCharge = professeurs[0];
+
+        // affecter ce prof à l'élève
+        eleve.professeur_id = professeurLeMoinsCharge.id;
+        await eleve.save(); // envoie le UPDATE en BDD
+
+        res.status(200).json({
+            message: 'Référent affecté automatiquement',
+            eleve,
+            professeur: professeurLeMoinsCharge
+        });
+
+    } catch (error) {
+        console.error('Erreur affecterAuto:', error);
+        res.status(500).json({ message: 'Erreur serveur' });
+    }
+};
+
+
+
+module.exports = { getEleves, affecter, affecterAuto, getAll };

--- a/api/routes/eleves.js
+++ b/api/routes/eleves.js
@@ -8,17 +8,20 @@ const router = express.Router();
 const eleveController = require('../controllers/eleveController');
 const moyenneController = require('../controllers/moyenneController');
 const optionController = require('../controllers/optionController');
+const professeurController = require('../controllers/professeurController');
 const verifyToken = require('../middlewares/verifyToken');
 const checkRole = require('../middlewares/checkRole');
 const upload = require('../middlewares/upload');
 
-router.get('/:id/options',  verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), optionController.getByEleve);
-router.get('/:id/moyennes', verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), moyenneController.getByEleve);
-router.post('/import',      verifyToken, checkRole('secretariat'), upload.single('fichier'), eleveController.importCSV);
-router.get('/',             verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), eleveController.getAll);
-router.get('/:id',          verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), eleveController.getById);
-router.post('/',            verifyToken, checkRole('secretariat'),                            eleveController.create);
-router.put('/:id',          verifyToken, checkRole('secretariat'),                            eleveController.update);
-router.delete('/:id',       verifyToken, checkRole('secretariat'),                            eleveController.remove);
+router.get('/:id/options',        verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), optionController.getByEleve);
+router.get('/:id/moyennes',       verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), moyenneController.getByEleve);
+router.post('/:id/referent/auto', verifyToken, checkRole('secretariat'                           ), professeurController.affecterAuto);
+router.post('/:id/referent',      verifyToken, checkRole('secretariat'                           ), professeurController.affecter);
+router.post('/import',            verifyToken, checkRole('secretariat'), upload.single('fichier'),  eleveController.importCSV);
+router.get('/',                   verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), eleveController.getAll);
+router.get('/:id',                verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), eleveController.getById);
+router.post('/',                  verifyToken, checkRole('secretariat'),                            eleveController.create);
+router.put('/:id',                verifyToken, checkRole('secretariat'),                            eleveController.update);
+router.delete('/:id',             verifyToken, checkRole('secretariat'),                            eleveController.remove);
 
 module.exports = router;

--- a/api/routes/professeurs.js
+++ b/api/routes/professeurs.js
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview Routes des professeurs
+ * @module routes/professeurs
+ */
+
+const express = require('express');
+const router = express.Router();
+const professeurController = require('../controllers/professeurController');
+const verifyToken = require('../middlewares/verifyToken');
+const checkRole = require('../middlewares/checkRole');
+
+router.get('/:id/eleves',         verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), professeurController.getEleves);
+router.get('/',                   verifyToken, checkRole('secretariat', 'proviseur', 'professeur'), professeurController.getAll);
+
+module.exports = router;

--- a/api/server.js
+++ b/api/server.js
@@ -10,6 +10,7 @@ const moyenne = require('./routes/moyenne')
 const stages = require('./routes/stages')
 const projets = require('./routes/projets')
 const options = require('./routes/options')
+const professeurs = require('./routes/professeurs')
 
 const app  = express()
 const PORT = process.env.PORT || 3000
@@ -21,6 +22,7 @@ app.use('/moyennes', moyenne)
 app.use('/stages', stages)
 app.use('/projets', projets)
 app.use('/options', options)
+app.use('/professeurs', professeurs)
 
 connectDB()
 require('./models')


### PR DESCRIPTION
## Description
Gestion des professeurs référents avec affectation manuelle et automatique (round-robin)

## Changements
- Ajout de `controllers/professeurController.js` - getAll, getEleves, affecter, affecterAuto
- Ajout de `routes/professeurs.js` 
- Maj de `routes/eleves.js` - ajout POST /:id/referent et POST /:id/referent/auto
- Maj de `server.js` 

## Tests (flashposts encore)
- GET /professeurs → liste tous les profs avec nb_eleves ✅
- GET /professeurs/:id/eleves → liste des élèves référents d'un prof ✅
- POST /eleves/:id/referent → affectation manuelle d'un référent ✅
- POST /eleves/:id/referent/auto → affectation automatique round-robin ✅

## Closes
Closes #22 