### PR TITLE
mail au(x) parent(s) avec nodemailer

### DIFF
--- a/api/controllers/mailController.js
+++ b/api/controllers/mailController.js
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview Contrôleur du publipostage parents
+ * @module controllers/mailController
+ */
+
+const nodemailer = require('nodemailer');
+const { Parent } = require('../models');
+
+/**
+ * Crée et retourne un transporteur nodemailer configuré via .env
+ * On le crée en fonction pour éviter de le garder en mémoire inutilement !!! 
+ */
+const createTransporter = () => nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS
+    }
+});
+
+/**
+ * envoie un email à un parent spécifique.
+ *
+ * @async
+ * @function mailOne
+ * @param {import('express').Request} req
+ * @param {string} req.params.id - id du parent
+ * @param {Object} req.body
+ * @param {string} req.body.sujet - objet de l'email
+ * @param {string} req.body.message - contenu de l'email
+ * @param {string} req.body.auteur - nom de l'expéditeur affiché en footer
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // POST /parents/1/mail
+ * // Body : { "sujet": "Convocation", "message": "...", "auteur": "M. Martin" }
+ * // Réponse 200 : { message: "Email envoyé" }
+ * // Réponse 400 : { message: "Champs manquants" }
+ * // Réponse 404 : { message: "Parent introuvable" }
+ */
+
+const mailOne = async (req, res) => {
+    try {
+        const { id } = req.params;
+        const { sujet, message, auteur } = req.body;
+
+        // Vérifie que tous les champs sont présents
+        if (!sujet || !message || !auteur) {
+            return res.status(400).json({ message: "Champs manquants" });
+        }
+
+        // Vérifie que le parent existe en BDD
+        const parent = await Parent.findByPk(id);
+        if (!parent) {
+            return res.status(404).json({ message: "Parent introuvable" });
+        }
+
+        const transporter = createTransporter();
+
+        // Envoie l'email au parent avec l'auteur en footer
+        await transporter.sendMail({
+            from: process.env.EMAIL_USER,
+            to: parent.email,
+            subject: sujet,
+            text: `${message}\n\n---\n${auteur}` // auteur ajouté en pied de message
+        });
+
+        res.status(200).json({ message: "Email envoyé" });
+
+    } catch (error) {
+        console.error('Erreur envoi email :', error);
+        res.status(500).json({ message: "Erreur serveur" });
+    }
+};
+
+/**
+ * envoie un email à tous les parents de l'établissement.
+ *
+ * @async
+ * @function mailAll
+ * @param {import('express').Request} req
+ * @param {Object} req.body
+ * @param {string} req.body.sujet - objet de l'email
+ * @param {string} req.body.message - contenu de l'email
+ * @param {string} req.body.auteur - nom de l'expéditeur affiché en footer
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ *
+ * @example
+ * // POST /parents/mail
+ * // Body : { "sujet": "Réunion parents", "message": "...", "auteur": "Secrétariat" }
+ * // Réponse 200 : { message: "Emails envoyés", total: 42 }
+ * // Réponse 400 : { message: "Champs manquants" }
+ * // Réponse 404 : { message: "Aucun parent trouvé" }
+ */
+
+const mailAll = async (req, res) => {
+    try {
+        const { sujet, message, auteur } = req.body;
+
+        // Vérifie que tous les champs sont présents
+        if (!sujet || !message || !auteur) {
+            return res.status(400).json({ message: "Champs manquants" });
+        }
+
+        // Récupère tous les parents en BDD
+        const parents = await Parent.findAll();
+        if (parents.length === 0) {
+            return res.status(404).json({ message: "Aucun parent trouvé" });
+        }
+
+        const transporter = createTransporter();
+
+        // Envoie un email individuel à chaque parent, sinon les parents verraient les autres mails
+        // RGPD : chaque parent ne voit que son propre email, pas ceux des autres
+        for (const parent of parents) {
+            await transporter.sendMail({
+                from: process.env.EMAIL_USER,
+                to: parent.email,
+                subject: sujet,
+                text: `${message}\n\n---\n${auteur}`
+            });
+        }
+
+        res.status(200).json({ message: "Emails envoyés", total: parents.length });
+
+    } catch (error) {
+        console.error('Erreur envoi emails :', error);
+        res.status(500).json({ message: "Erreur serveur" });
+    }
+};
+
+module.exports = { mailOne, mailAll };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.1.1",
+        "nodemailer": "^8.0.4",
         "pdfkit": "^0.18.0",
         "pg": "^8.20.0",
         "pg-hstore": "^2.3.4",
@@ -1185,6 +1186,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
+      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/api/package.json
+++ b/api/package.json
@@ -21,6 +21,7 @@
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.1.1",
+    "nodemailer": "^8.0.4",
     "pdfkit": "^0.18.0",
     "pg": "^8.20.0",
     "pg-hstore": "^2.3.4",

--- a/api/routes/mails.js
+++ b/api/routes/mails.js
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview Routes du publipostage
+ * @module routes/mails
+ */
+
+const express = require('express');
+const router = express.Router();
+const mailController = require('../controllers/mailController');
+const verifyToken = require('../middlewares/verifyToken');
+const checkRole = require('../middlewares/checkRole');
+
+router.post('/all',      verifyToken, checkRole('secretariat', 'professeur', 'proviseur'), mailController.mailAll);
+router.post('/:id/mail', verifyToken, checkRole('secretariat', 'professeur', 'proviseur'), mailController.mailOne);
+
+module.exports = router;

--- a/api/server.js
+++ b/api/server.js
@@ -13,6 +13,7 @@ const options = require('./routes/options')
 const professeurs = require('./routes/professeurs')
 const conventions = require('./routes/convention')
 const attestations = require('./routes/attestations')
+const mails = require('./routes/mails')
 
 const app  = express()
 const PORT = process.env.PORT || 3000
@@ -27,6 +28,7 @@ app.use('/options', options)
 app.use('/professeurs', professeurs)
 app.use('/conventions', conventions)
 app.use('/attestations', attestations)
+app.use('/mails', mails)
 
 connectDB()
 require('./models')


### PR DESCRIPTION
## Description
Implémentation du publipostage parents avec envoi individuel et groupé avec Nodemailer

## Changements
- Ajout de `controllers/mailController.js` - mailOne, mailAll
- Ajout de `routes/mails.js` -  routes sécurisées par rôle
- Mise à jour de `middlewares/upload.js` -ajout uploadPdf
- Mise à jour de `server.js
- Install nodemailer

## Tests avec flahspost
- POST /mails/all → envoi à tous les parents ✅
- POST /mails/:id/mail → envoi à un parent spécifique ✅

## Closes
Closes #38 